### PR TITLE
feat: Add build with artefact upload

### DIFF
--- a/.github/workflows/symbiote-build.yml
+++ b/.github/workflows/symbiote-build.yml
@@ -5,7 +5,7 @@ on:
   push:
 
 jobs:
-  quick-smoke:
+  build:
     runs-on: ubuntu-latest
     container:
       image: quay.io/bluebird/java-builder:0.0.1.jdk-21.b24
@@ -13,9 +13,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Build from source without expensive tasks
+      - name: Build from source
         run: |
-          make
+          make build
       - name: Run tests
         run: |
           make tests

--- a/.github/workflows/symbiote-build.yml
+++ b/.github/workflows/symbiote-build.yml
@@ -1,0 +1,26 @@
+---
+name: symbiote-build
+run-name: Build and run test suites
+on:
+  push:
+
+jobs:
+  quick-smoke:
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/bluebird/java-builder:0.0.1.jdk-21.b24
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build from source without expensive tasks
+        run: |
+          make
+      - name: Run tests
+        run: |
+          make tests
+      - name: Persist build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: eventbus-jar
+          path: target/eventbus-*.jar

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ build/
 .DS_Store
 
 application-local.properties
+
+### jenv ###
+.java-version
+

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ tests:
 	mvn test
 
 .PHONY: build
-build: clean
+build:
 	mvn install -DskipTests
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+.DEFAULT_GOAL := compile
+
+.PHONY: help
+help:
+	@echo ""
+	@echo "help:        Show this help"
+	@echo "compile:     Compile the source code"
+	@echo "tests:       Build the source code and run tests."
+	@echo "clean:       Clean build artifacts"
+	@echo ""
+
+.PHONY: deps
+deps:
+	command -v java
+	command -v mvn
+	@echo "Check Java JDK version 21"
+	@java -version 2>&1 | grep "version \"21\..*\""
+
+.PHONY: compile
+compile: deps
+	mvn compile
+
+.PHONY: tests
+tests:
+	mvn test
+
+clean:
+	mvn clean

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ help:
 	@echo "help:        Show this help"
 	@echo "compile:     Compile the source code"
 	@echo "tests:       Build the source code and run tests."
+	@echo "build:       Run a clean build with mvn install -DskipTests"
 	@echo "clean:       Clean build artifacts"
 	@echo ""
 
@@ -24,5 +25,10 @@ compile: deps
 tests:
 	mvn test
 
+.PHONY: build
+build: clean
+	mvn install -DskipTests
+
+.PHONY: clean
 clean:
 	mvn clean

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# Symbionte Prototype
+# Symbionte - Request for Comments
 
-**NOTE: THIS IS A PROTOTYPE**
+> [!IMPORTANT]  
+> This a prototype to challenge the idea come up with a concept of dealing and managing monitoring events.
 
-The `Symbiote Prototype` consumes `OpenNMS Horizon` events (implementd), alarms (not implemented) and nodes (not implemented) to allow working on the conceptional debt mentioned [here](https://opennms.discourse.group/t/the-future-of-opennms-horizon/3952).
+The `Symbiote Prototype` consumes `OpenNMS Horizon` events (implemented), alarms (not implemented) and nodes (not implemented) to allow working on the conceptional debt mentioned [here](https://opennms.discourse.group/t/the-future-of-opennms-horizon/3952).
 
 ## What does it do
 
@@ -11,8 +12,6 @@ The `Symbiote` listens to `OpenNMS Horizon` events - sent by the `KafkaEventProd
 Besides this it implements a very basic event escalation model (similar to the OpenNMS Horizon's one). If an event is escalated to an alarm, it is persisted to a (temporary) postgres database table: `alarms`.
 
 ## Alarm Definition Model
-
-**NOTE: This is a prototype, proof-of-concept**
 
 An alarm is defined as follows:
 
@@ -45,11 +44,8 @@ At the moment the alarm definitions are automatically calculated on the basis of
 
 ### Alarm Propagation
 
-**NOTE: This is a prototype, proof-of-concept**
-
 If an alarm is created, an according `alarmPropagation/${originalEvent.uei}` event is sent out, with a consolidation key of `"alarmPropagation/${originalEvent.consolidationKey}/level=${originalEvent.level == null ? 0 : 1}:${originalEvent.level == null ? 1 : originalEvelt.level + 1}"`.
 This allows for alarm definitions to "listen" for these events and therefore allow implementing a very basic alarm propagation model.
-
 
 ```
 UEI: alarmPropagation/uei.opennms.org/nodes/nodeDown
@@ -86,8 +82,6 @@ At the moment there are two implementations available by default:
 
 ## Event Model
 
-**NOTE: This is a prototype, proof-of-concept**
-
 There are two implemented event models: `EventLogEntity` and `EventDTO`.
 At the moment only `EventDTO` is used.
 
@@ -95,7 +89,6 @@ The goal here is to find a generic, but yet concrete enough data model to work o
 For example the `properties` and `payload` in there could be used both, or just one, depending on how we want to model things. Whereas the `EventLogEntity` is probably too close to the original `OpenNMS Horizon` event data model.
 
 TL;DR: Model works for this use case but obviously not in a "productive" system.
-
 
 ## How to get it started
 
@@ -114,7 +107,6 @@ Install and configure the `Kafka Producer`.
 Installation guide: https://docs.opennms.com/horizon/30/operation/kafka-producer/enable-kafka.html
 
 Configuration guide: https://docs.opennms.com/horizon/30/operation/kafka-producer/configure-kafka.html
-
 
 TL;DR: 
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,3 +1,4 @@
+---
 services:
   zookeeper:
     image: confluentinc/cp-zookeeper:7.4.4

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <revision>0.0.1-SNAPSHOT</revision>
         <java.version>21</java.version>
-        <os.detected.classifier>osx-x86_64</os.detected.classifier>
         <version.opennms.integration.api>1.6.0</version.opennms.integration.api>
     </properties>
     <dependencies>
@@ -105,5 +104,12 @@
                 </executions>
             </plugin>
         </plugins>
+        <extensions>
+            <extension>
+                <version>1.7.0</version>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+            </extension>
+        </extensions>
     </build>
 </project>


### PR DESCRIPTION
Created a GitHub actions pipeline with an artifact upload to have something people can play with. The Google Protobuf was hardcoded to OSX x86_64 hardware. I've added a plugin that detects the architecture and allows it to build also on non-OSX systems.